### PR TITLE
Step 1: Document CWL and Perl behavior for SE-first conversion

### DIFF
--- a/docs/cwl_pipeline_spec.md
+++ b/docs/cwl_pipeline_spec.md
@@ -1,0 +1,137 @@
+# CWL Pipeline Specification
+
+## Scope
+This document describes the current CWL graph with emphasis on SE (`wf_ecliprepmap_se.cwl`) because conversion priority is SE first, followed by PE.
+
+## Top-level SE workflow: `cwl/wf_ecliprepmap_se.cwl`
+
+### Inputs
+- `dataset` (string)
+- IP sample:
+  - `barcode1r1FastqGz` (File)
+  - `barcode1rmRepBam` (File)
+- Input/control sample:
+  - `barcode1Inputr1FastqGz` (File)
+  - `barcode1InputrmRepBam` (File)
+- Reference/config:
+  - `bowtie2_db` (Directory)
+  - `bowtie2_prefix` (string)
+  - `fileListFile1` (File)
+  - `gencodeGTF` (File)
+  - `gencodeTableBrowser` (File)
+  - `repMaskBEDFile` (File)
+- Runtime defaults:
+  - `prefixes` (string[], 25 two-base UMI prefixes from `AA` to `NN`)
+  - `se_or_pe` (string, default `SE`)
+
+### Steps
+1. `step_ecliprepmap_barcode1`
+- Runs subworkflow `wf_ecliprepmap_se_1barcode.cwl` for IP sample.
+- Derives internal `dataset` name from input FASTQ nameroot with `.barcode1` suffix.
+
+2. `step_ecliprepmap_input`
+- Runs same subworkflow for Input sample.
+- Derives internal `dataset` name from input FASTQ nameroot with `.input` suffix.
+
+3. `step_calculate_fold_change_from_parsed_files`
+- Runs `calculate_fold_change_from_parsed_files.cwl` over combined parsed outputs from IP vs Input.
+
+### Outputs
+- Pre-rmdup SAM-like gz:
+  - `output_ip_concatenated_pre_rmDup_sam_file`
+  - `output_input_concatenated_pre_rmDup_sam_file`
+- Rmdup SAM-like gz:
+  - `output_barcode1_concatenated_rmDup_sam_file`
+  - `output_input_concatenated_rmDup_sam_file`
+- Parsed stats and fold-change tables:
+  - `output_ip_parsed`
+  - `output_input_parsed`
+  - `output_nopipes`
+  - `output_withpipes`
+
+## One-barcode SE subworkflow: `cwl/wf_ecliprepmap_se_1barcode.cwl`
+
+### Step graph (execution order)
+1. `step_map_repetitive_elements` -> `map_repetitive_elements_se.cwl`
+2. `step_splitbam_repsam` -> `splitbam.cwl`
+3. `step_splitbam_rmrepbam` -> `splitbam.cwl`
+4. `step_getpair` (scatter over 25 `prefixes`) -> `getpair.cwl`
+5. `step_deduplicate` (dotproduct scatter over prefix-matched rep/rmrep files) -> `deduplicate.cwl`
+6. `step_concatenate_rmDup` -> `concatenate.cwl`
+7. `step_concatenate_preRmDup` -> `concatenate.cwl`
+8. `step_gzip_rmDup` -> `gzip.cwl`
+9. `step_gzip_preRmDup` -> `gzip.cwl`
+10. `step_combine_parsed` -> `combine.cwl`
+
+### Subworkflow outputs
+- `output_repeat_mapped_sam_file` (`.Rep.sam`)
+- `output_rmDup_sam_files` (array of per-prefix rmdup SAM-like files)
+- `output_pre_rmDup_sam_files` (array of per-prefix pre-rmdup SAM-like files)
+- `output_concatenated_rmDup_sam_file` (gz)
+- `output_concatenated_preRmDup_sam_file` (gz)
+- `output_parsed_files` (array of parsed per-prefix files)
+- `output_combined_parsed_file` (combined `.parsed`)
+
+## CommandLineTool contracts used by SE
+
+### `cwl/map_repetitive_elements_se.cwl`
+- Base command: `parse_bowtie2_output_realtime_includemultifamily_SE.pl`
+- Positional args:
+  1. `read1`
+  2. `bowtie2_db.path + "//" + bowtie2_prefix`
+  3. `output_file` (default: `<read1.nameroot>.Rep.sam`)
+  4. `file_list_file`
+- Output: `rep_sam` (SAM-like file)
+
+### `cwl/splitbam.cwl`
+- Base command: `split_bam_to_subfiles_SEorPE.pl`
+- Positional args: `sam_file`, `se_or_pe`
+- Output glob: `*.tmp`
+- Behavior depends on SE/PE flag and input extension (`.sam` vs `.bam`)
+
+### `cwl/getpair.cwl` (ExpressionTool)
+- Inputs: one `prefix`, `rep_s[]`, `rmrep_s[]`
+- Returns the file in each array whose basename starts with prefix.
+- Outputs: `prefixrep`, `prefixrmrep`
+
+### `cwl/deduplicate.cwl`
+- Base command: `duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.pl`
+- Positional args:
+  1. `repFamilySam`
+  2. `rmRepSam`
+  3. `se_or_pe`
+  4. `gencodeGTF`
+  5. `gencodeTableBrowser`
+  6. `repMaskBedFile`
+  7. `fileList1`
+- Outputs:
+  - `*combined_w_uniquemap.rmDup.sam`
+  - `*combined_w_uniquemap.prermDup.sam`
+  - `*.parsed_v2.20201210.txt`
+  - `*.done`
+
+### `cwl/concatenate.cwl`
+- Base command: `cat`
+- Inputs: `files[]`
+- `stdout` redirected to provided `concatenated_output` filename.
+
+### `cwl/gzip.cwl`
+- Base command: `gzip -c <input>`
+- Output filename: `<input.basename>.gz`
+
+### `cwl/combine.cwl`
+- Base command: `merge_multiple_parsed_files.simplified_20191022.pl`
+- Args: `outputFile`, then `files[]`
+- Output glob: `outputFile`
+
+### `cwl/calculate_fold_change_from_parsed_files.cwl`
+- Base command: `calculate_fold_change_from_parsed_files.py`
+- Required args: `--ip_parsed`, `--input_parsed`
+- Defaults:
+  - `--out_file_nopipes`: `<ip_parsed.nameroot>.nopipes.tsv`
+  - `--out_file_withpipes`: `<ip_parsed.nameroot>.withpipes.tsv`
+
+## PE workflow notes (for subsequent conversion phase)
+- `cwl/wf_ecliprepmap_pe.cwl` runs `wf_ecliprepmap_pe_1barcode.cwl` for barcode1, barcode2, and input.
+- It adds cross-barcode `combine`, `concatenate`, and gzip at top level.
+- The one-barcode PE subworkflow mirrors SE structure but uses PE mapping parser (`map_repetitive_elements_pe.cwl`) and PE reads (R1/R2).

--- a/docs/output_format_spec.md
+++ b/docs/output_format_spec.md
@@ -1,0 +1,75 @@
+# Output Format Specification (Observed + Code-Aligned)
+
+## Source basis
+- Observed files under `data/PPA1_rep1/results/*.gz`.
+- CWL tool wiring and Perl/Python scripts.
+
+## 1) `.parsed` and `.reparsed.tsv`-style summary files
+
+### Header lines
+Common readinfo-like rows begin with `#READINFO`.
+Observed keys:
+- `AllReads` (in `.parsed`, not always present in reparsed files)
+- `UsableReads`
+- `GenomicReads`
+- `RepFamilyReads`
+
+### Body rows
+Two row classes:
+- `TOTAL\t<family>\t<read_count>\t<fraction_or_rpm>`
+- `ELEMENT\t<primary_label>\t<read_count>\t<fraction_or_rpm>\t<element_bundle>\t<gene_bundle>`
+
+Notes:
+- Some files labeled `.reparsed.tsv.gz` retain `TOTAL` rows but may omit initial `AllReads` line.
+- Floating precision differs by script/formatting (`sprintf` in Perl; pandas/float formatting in Python).
+
+## 2) `.nopipes.tsv` and `.withpipes.tsv`
+Tab-separated with header:
+- `element`
+- `IP_read_num`
+- `IP_clip_rpr`
+- `Input_read_num`
+- `Input_clip_rpr`
+- `Fold_enrichment`
+- `Information_content`
+
+Meaning:
+- `clip_rpr` terms are read proportion metrics.
+- `Fold_enrichment = IP_clip_rpr / Input_clip_rpr` (with pseudocount handling in upstream script).
+- `Information_content = IP_clip_rpr * log2(IP_clip_rpr / Input_clip_rpr)`.
+- `.nopipes.tsv` excludes ambiguous multi-family mappings (contains no `|` in element family labels).
+- `.withpipes.tsv` includes both ambiguous and unambiguous families.
+
+## 3) SAM-like pre-rmdup and rmdup outputs
+Examples:
+- `*.preRmDup.sam.gz`
+- `*.rmDup.sam.gz`
+
+Characteristics:
+- Tab-delimited SAM fields preserved.
+- Additional right-side annotations are appended beyond canonical SAM tags.
+- `ZZ:Z:` tags may include pipe-delimited ENST sets.
+- rmdup files append classification fields such as:
+  - `RepFamily` / `UniqueGenomic`
+  - normalized family/element label string
+
+## 4) mpileup-short outputs
+Examples:
+- `*.rmDup.sam.gz.tmp.RNA18S.bam.sorted.bam.mpileup.short.gz`
+- `*.rmDup.sam.gz.tmp.RNA28S.bam.sorted.bam.mpileup.short.gz`
+
+Observed columns:
+1. transcript/accession id
+2. 1-based position
+3. reference base
+4. depth/count
+
+## 5) Determinism/tolerance for validation
+Validation should be tolerant for:
+- floating point formatting differences
+- row ordering differences where hash/dict iteration affects output order
+
+Validation should be strict for:
+- schema/column set
+- primary key identity (element/family labels)
+- integer read counts

--- a/docs/perl_scripts_spec.md
+++ b/docs/perl_scripts_spec.md
@@ -1,0 +1,122 @@
+# Perl Script Specification (Current Repository)
+
+## Conversion Scope Decision
+Per user-approved scope:
+- Convert scripts used by CWL workflow execution path.
+- Exclude legacy/non-CWL wrappers if not in workflow path:
+  - `bin/perl/RepElement_pipeline_1dataset.pl` (excluded)
+  - `bin/perl/duplicate_removal.pl` (excluded)
+
+## In-scope scripts
+
+### `bin/perl/parse_bowtie2_output_realtime_includemultifamily_SE.pl`
+Purpose:
+- Align SE reads with bowtie2 and emit SAM-like repetitive-element assignments with family/element annotations.
+
+CLI (from script):
+1. `fastq_file1`
+2. `bowtie_db` prefix
+3. `output` SAM-like file
+4. `filelist_file` mapping ENST -> type/priority
+
+Outputs:
+- Main: `<output>`
+- Side files:
+  - `<output>.bowtieout`
+  - `<output>.multimapping_deleted`
+  - `<output>.done`
+
+Behavior highlights:
+- Streams bowtie2 output (`--sensitive -a --reorder`).
+- Applies family prioritization and special rRNA handling (`RNA45S` vs `RNA18S/28S/5-8S` rules).
+- Emits `ZZ:Z:` tag with multiple compatible ENSTs.
+
+### `bin/perl/parse_bowtie2_output_realtime_includemultifamily_PE.pl`
+Purpose:
+- Same as SE parser but for paired-end reads.
+
+CLI:
+1. `fastq_file1`
+2. `fastq_file2`
+3. `bowtie_db` prefix
+4. `output` SAM-like file
+5. `filelist_file`
+
+Outputs:
+- Main: `<output>`
+- Side files: `.bowtieout`, `.multimapping_deleted`, `.done`
+
+Behavior highlights:
+- Reads bowtie2 SAM stream in paired-record chunks.
+- Enforces read-name pairing checks.
+- Maintains multi-family assignment bookkeeping.
+
+### `bin/perl/split_bam_to_subfiles_SEorPE.pl`
+Purpose:
+- Split a SAM/BAM into 25 temporary files by first two UMI nucleotides.
+
+CLI:
+1. `sam_fi` (`.sam` or `.bam`)
+2. `se_or_pe_flag` (`SE` or `PE`)
+
+Outputs:
+- `AA.<sam_basename>.tmp` ... `NN.<sam_basename>.tmp` in current working dir.
+
+Behavior highlights:
+- For BAM input, uses `samtools view -h` pipe.
+- Skips unmapped reads (`flag 4` for SE; `77/141` for PE).
+- In PE mode, assumes paired records are adjacent and may reorder interpretation by flag.
+
+### `bin/perl/duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.pl`
+Purpose:
+- Merge repeat-mapped SAM-like records with genome-mapped records and remove PCR duplicates.
+- Produce rmdup/pre-rmdup SAM-like outputs and parsed count summaries.
+
+CLI:
+1. `repfamily_sam`
+2. `gabe_rmRep_sam`
+3. `eCLIP_read_type_flag` (`SE`/`PE`)
+4. `gencode_gtf_file`
+5. `gencode_tablebrowser_file`
+6. `repmask_bed_fi`
+7. `filelist_file`
+
+Outputs (derived from input basename):
+- `<repfamily_sam_short>.combined_w_uniquemap.rmDup.sam`
+- `<repfamily_sam_short>.combined_w_uniquemap.prermDup.sam`
+- `<rmDup>.parsed_v2.20201210.txt`
+- `<output>.done`
+
+Behavior highlights:
+- SE and PE logic diverges after shared annotation loading.
+- Uses per-read keys including UMI, strand, coordinates for deduping.
+- Produces #READINFO lines + TOTAL/ELEMENT summaries.
+
+### `bin/perl/merge_multiple_parsed_files.simplified_20191022.pl`
+Purpose:
+- Merge multiple per-prefix parsed files into one dataset-level parsed file.
+
+CLI:
+1. `output_fi`
+2. `parsed_file_1`
+3. `parsed_file_2`
+4. ...
+
+Outputs:
+- `output_fi`
+- Appends to `failed_jobs_list.txt` in inferred working directory using a lock file.
+
+Behavior highlights:
+- Sums readinfo counters across parsed inputs.
+- Aggregates `TOTAL` and `ELEMENT` rows, then sorts by descending counts.
+- Emits four canonical `#READINFO` lines in merged output.
+
+## Out-of-scope scripts in this phase
+
+### `bin/perl/RepElement_pipeline_1dataset.pl`
+- Legacy wrapper generating shell/PBS pipeline commands.
+- Not called by CWL workflow files.
+
+### `bin/perl/duplicate_removal.pl`
+- Older variant of duplicate-removal logic.
+- Not referenced by `cwl/deduplicate.cwl`.

--- a/docs/python_conversion_roadmap.md
+++ b/docs/python_conversion_roadmap.md
@@ -1,0 +1,109 @@
+# Python + Snakemake Conversion Roadmap
+
+Base branch: `codex/python-conversion`
+
+## Goals
+1. Understand and document CWL pipeline and Perl scripts in this repository.
+2. Understand and document the provided inputs in `data/` and the PPA1 example outputs in `data/PPA1_rep1*`.
+3. Generate small deterministic test files derived from the PPA1 example.
+4. Convert each Perl script in `bin/perl/` to Python.
+5. Convert CWL workflow steps to Snakemake incrementally and test each step output vs expected.
+
+## Current Observations (from repository)
+- Main SE workflow path for PPA1 example:
+  - `cwl/wf_ecliprepmap_se.cwl`
+  - nested `cwl/wf_ecliprepmap_se_1barcode.cwl`
+  - tools: `map_repetitive_elements_se.cwl`, `splitbam.cwl`, `getpair.cwl`, `deduplicate.cwl`, `concatenate.cwl`, `gzip.cwl`, `combine.cwl`, `calculate_fold_change_from_parsed_files.cwl`
+- Main PE workflow path:
+  - `cwl/wf_ecliprepmap_pe.cwl`, `cwl/wf_ecliprepmap_pe_1barcode.cwl`
+- Perl scripts to convert (`bin/perl/`):
+  - `RepElement_pipeline_1dataset.pl`
+  - `duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.pl`
+  - `duplicate_removal.pl`
+  - `merge_multiple_parsed_files.simplified_20191022.pl`
+  - `parse_bowtie2_output_realtime_includemultifamily_SE.pl`
+  - `parse_bowtie2_output_realtime_includemultifamily_PE.pl`
+  - `split_bam_to_subfiles_SEorPE.pl`
+- Data location in this workspace:
+  - `data` is a symlink to `/Volumes/X9Pro/Yeo/repetitive-element-pipeline`
+  - Example SE run exists at `data/PPA1_rep1/` with `results/*.gz`, input YAML, and workflow log/output JSON.
+
+## Step-by-Step Execution Plan
+
+### Step 1: Pipeline + Script Documentation
+Deliverables:
+- `docs/cwl_pipeline_spec.md`: tool-by-tool and step dependency documentation for SE and PE workflows.
+- `docs/perl_scripts_spec.md`: each Perl script CLI contract, inputs, outputs, side effects, and edge-case behavior notes.
+- `docs/output_format_spec.md`: `.parsed`, `.reparsed.tsv`, `.nopipes.tsv`, `.withpipes.tsv`, SAM-like and mpileup-short field-level definitions inferred from files + code.
+
+Validation:
+- Cross-check docs against CWL inputs/outputs and real files in `data/PPA1_rep1/results`.
+
+### Step 2: Input + Example Characterization
+Deliverables:
+- `docs/data_inventory.md`: every input artifact used by PPA1 example (paths, file types, sample line structure, compression).
+- `docs/ppa1_expected_outputs_manifest.tsv`: canonical list of expected files and lightweight fingerprints (size, sha256).
+
+Validation:
+- deterministic fingerprint generation scripts and reproducible inventory command.
+
+### Step 3: Create Small Test Fixtures
+Deliverables:
+- `tests/fixtures/mini/` with reduced-size SE inputs derived from PPA1 (small FASTQ/BAM/reference slices).
+- `scripts/make_mini_fixtures.py` to regenerate fixtures deterministically.
+- `tests/fixtures/mini/expected/` expected outputs for mini run.
+
+Validation:
+- fixture-generation test and manifest checksums.
+
+### Step 4: Perl -> Python Conversion
+Deliverables:
+- New Python equivalents under `bin/python/` (one file per Perl script) with CLI parity.
+- shared utilities module for parsing SAM/BAM and table records where appropriate.
+- regression tests for each converted script on synthetic + mini fixture cases.
+
+Migration strategy:
+- convert one script at a time in this order:
+  1) `split_bam_to_subfiles_SEorPE.pl`
+  2) `merge_multiple_parsed_files.simplified_20191022.pl`
+  3) `parse_bowtie2_output_realtime_includemultifamily_SE.pl`
+  4) `parse_bowtie2_output_realtime_includemultifamily_PE.pl`
+  5) `duplicate_removal_inline_..._simple.pl`
+  6) `duplicate_removal.pl`
+  7) `RepElement_pipeline_1dataset.pl` (legacy wrapper)
+
+Validation:
+- script-level golden tests compare normalized outputs with Perl baseline.
+
+### Step 5: CWL -> Snakemake Conversion (Incremental)
+Deliverables:
+- `Snakefile`, `workflow/rules/*.smk`, `config/config.yaml`, `workflow/envs/*.yaml`.
+- first target scope: SE pipeline matching `wf_ecliprepmap_se.cwl` + `_1barcode` behavior.
+- second target scope: PE parity.
+
+Incremental conversion/testing sequence (SE first):
+1. map repetitive elements
+2. split rep sam
+3. split rmRep bam
+4. prefix pairing logic (`getpair` equivalent)
+5. deduplicate
+6. concatenate + gzip outputs
+7. combine parsed files
+8. fold-change tables
+
+Validation at each step:
+- compare produced files to expected for mini fixture and (where feasible) PPA1 reference outputs.
+- compare row counts, key columns, and checksum (exact when deterministic; tolerant numeric comparison where needed).
+
+## Branching / PR Execution Strategy
+- Keep `codex/python-conversion` as integration base branch.
+- For each completed roadmap step, create branch `codex/python-conversion-stepN-<shortname>` from latest `codex/python-conversion`.
+- Commit/push branch and open PR targeting `codex/python-conversion`.
+- After PR creation, fast-forward/merge locally into `codex/python-conversion` before starting next step branch.
+
+## Tooling Gaps Identified Locally
+Currently found in PATH:
+- present: `perl`, `samtools`, `gzip`
+- missing: `snakemake`, `bowtie2`, `cwltool`
+
+These are required to fully execute conversion/verification end-to-end.


### PR DESCRIPTION
## Summary
- add conversion roadmap for SE-first then PE
- document CWL SE workflow graph and tool contracts
- document in-scope Perl script interfaces and explicitly excluded legacy scripts
- document observed output formats and tolerant-validation rules

## Notes
- scope follows user confirmation: SE first, tolerant numeric/ordering comparison
- environment for execution is project-local at .conda-env