### PR TITLE
Step 4a: Convert split/merge Perl utilities to Python

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,6 +111,7 @@ tests/*
 !tests/fixtures/
 !tests/fixtures/**
 !tests/test_mini_fixtures_manifest.py
+!tests/test_split_merge_parity.py
 tests/__pycache__/
 tests/*.pyc
 

--- a/bin/python/merge_multiple_parsed_files.simplified_20191022.py
+++ b/bin/python/merge_multiple_parsed_files.simplified_20191022.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import fcntl
+from collections import defaultdict
+from pathlib import Path
+import re
+import sys
+
+
+READINFO_RE = re.compile(
+    r'All\sreads\:\t(\d+)\tPCR\sduplicates\sremoved\:\t(\d+)\tUsable\sRemaining\:\t(\d+)\tUsable\sfrom\sgenomic\smapping\:\t(\d+)\tUsable\sfrom\sfamily\smapping\:\t(\d+)$'
+)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description='Merge parsed files')
+    ap.add_argument('output_fi')
+    ap.add_argument('files', nargs='+')
+    args = ap.parse_args()
+
+    output_fi = Path(args.output_fi)
+    files = [Path(p) for p in args.files]
+
+    split_fi1 = list(files[0].parts)
+    short_fi1 = split_fi1[-1]
+    working_dir = Path(*split_fi1[:-1]) if len(split_fi1) > 1 else Path('.')
+    failed_jobs_list = working_dir / 'failed_jobs_list.txt'
+
+    print(f'SHORTFI:{short_fi1}', end='')
+    print(f'WORKDIR:{working_dir}', end='')
+
+    lock_fi = Path(str(failed_jobs_list) + '.lck')
+    lock_fi.parent.mkdir(parents=True, exist_ok=True)
+    with lock_fi.open('w') as s:
+        fcntl.flock(s.fileno(), fcntl.LOCK_EX)
+        with failed_jobs_list.open('a'):
+            pass
+
+    read_sums = {
+        'all': 0,
+        'usable': 0,
+        'genomic': 0,
+        'repfamily': 0,
+        'total': defaultdict(int),
+        'element': defaultdict(lambda: {'ensg_all': None, 'ensg_primary': None, 'readnum': 0}),
+    }
+
+    for parsed_file in files:
+        parse_file(parsed_file, read_sums)
+
+    output_fi.parent.mkdir(parents=True, exist_ok=True)
+    with output_fi.open('w', encoding='utf-8') as out:
+        usable = read_sums['usable']
+        all_reads = read_sums['all']
+        genomic = read_sums['genomic']
+        repfamily = read_sums['repfamily']
+
+        out.write(f'#READINFO\tAllReads\t{all_reads}\n')
+        out.write(f'#READINFO\tUsableReads\t{usable}\t{usable / all_reads if all_reads else 0}\n')
+        out.write(f'#READINFO\tGenomicReads\t{genomic}\t{genomic / usable if usable else 0}\n')
+        out.write(f'#READINFO\tRepFamilyReads\t{repfamily}\t{repfamily / usable if usable else 0}\n')
+
+        for element, readnum in sorted(read_sums['total'].items(), key=lambda kv: kv[1], reverse=True):
+            out.write(f'TOTAL\t{element}\t{readnum}\t{(readnum / usable) if usable else 0}\n')
+
+        items = sorted(
+            read_sums['element'].items(),
+            key=lambda kv: kv[1]['readnum'],
+            reverse=True,
+        )
+        for element, info in items:
+            out.write(
+                f"ELEMENT\t{info['ensg_primary']}\t{info['readnum']}\t"
+                f"{(info['readnum'] / usable) if usable else 0}\t{element}\t{info['ensg_all']}\n"
+            )
+
+    return 0
+
+
+def parse_file(parsed_fi: Path, read_sums: dict) -> None:
+    with parsed_fi.open('r', encoding='utf-8', errors='replace') as fh:
+        for raw in fh:
+            line = raw.rstrip('\n')
+            tmp = line.split('\t')
+            if not tmp:
+                continue
+            if tmp[0] == '#READINFO':
+                m = READINFO_RE.search(line)
+                if m:
+                    read_sums['all'] += int(m.group(1))
+                elif len(tmp) > 2 and tmp[1] == 'UsableReads':
+                    read_sums['usable'] += int(float(tmp[2]))
+                elif len(tmp) > 2 and tmp[1] == 'GenomicReads':
+                    read_sums['genomic'] += int(float(tmp[2]))
+                elif len(tmp) > 2 and tmp[1] == 'RepFamilyReads':
+                    read_sums['repfamily'] += int(float(tmp[2]))
+                else:
+                    print(f"couldn't parse readinfo line {line}", file=sys.stderr)
+            elif tmp[0] == '#READINFO2':
+                continue
+            elif tmp[0] == 'TOTAL':
+                _, element, readnum, *_ = tmp
+                read_sums['total'][element] += int(float(readnum))
+            else:
+                if len(tmp) < 6:
+                    continue
+                _, ensg_primary, readnum, _, enst_all, ensg_all = tmp[:6]
+                existing = read_sums['element'][enst_all]
+                if existing['ensg_all'] is not None and existing['ensg_all'] != ensg_all:
+                    print(
+                        f"error - ensg_all mismatch {ensg_all} {existing['ensg_all']}",
+                        file=sys.stderr,
+                    )
+                if existing['ensg_primary'] is not None and existing['ensg_primary'] != ensg_primary:
+                    print(
+                        f"error - ensg_primary mismatch {ensg_primary} {existing['ensg_primary']}",
+                        file=sys.stderr,
+                    )
+                existing['ensg_all'] = ensg_all
+                existing['ensg_primary'] = ensg_primary
+                existing['readnum'] += int(float(readnum))
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/bin/python/split_bam_to_subfiles_SEorPE.py
+++ b/bin/python/split_bam_to_subfiles_SEorPE.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+
+PREFIXES = [a + b for a in 'ACGTN' for b in 'ACGTN']
+
+
+def sam_stream(path: Path):
+    if path.suffix == '.sam':
+        with path.open('r', encoding='utf-8', errors='replace') as fh:
+            for line in fh:
+                yield line
+    elif path.suffix == '.bam':
+        proc = subprocess.Popen(
+            ['samtools', 'view', '-h', str(path)],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+        )
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            yield line
+        stderr = proc.stderr.read() if proc.stderr else ''
+        ret = proc.wait()
+        if ret != 0:
+            raise RuntimeError(f'samtools view failed ({ret}): {stderr}')
+    else:
+        raise ValueError(f'weird - {path} not either sam or bam file format - exit')
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description='Split SAM/BAM into 25 UMI-prefix tmp files')
+    ap.add_argument('sam_fi')
+    ap.add_argument('se_or_pe_flag', choices=['SE', 'PE'])
+    args = ap.parse_args()
+
+    sam_path = Path(args.sam_fi)
+    sam_short = sam_path.name
+    mode = args.se_or_pe_flag
+
+    if mode == 'PE':
+        print('splitting in paired-end mode', file=sys.stderr)
+    else:
+        print('splitting in single-end mode', file=sys.stderr)
+
+    filehandles = {
+        p: (Path(f'{p}.{sam_short}.tmp')).open('w', encoding='utf-8')
+        for p in PREFIXES
+    }
+
+    try:
+        stream = sam_stream(sam_path)
+        it = iter(stream)
+        for r1 in it:
+            if r1.startswith('@'):
+                continue
+            r1 = r1.rstrip('\n')
+            tmp_r1 = r1.split('\t')
+            r1_name = tmp_r1[0].split()[0]
+            r1_flag = int(tmp_r1[1])
+
+            r2 = None
+            tmp_r2: list[str] | None = None
+            if mode == 'PE':
+                try:
+                    r2 = next(it).rstrip('\n')
+                except StopIteration:
+                    break
+                tmp_r2 = r2.split('\t')
+                r2_name = tmp_r2[0].split()[0]
+                if r1_name != r2_name:
+                    print(
+                        f'paired end mismatch error: {sam_path} r1 {tmp_r1[0]} r2 {tmp_r2[0]}',
+                        file=sys.stderr,
+                    )
+                if not r1_flag:
+                    print(f'error {r1} {r2}', file=sys.stderr)
+
+            if mode == 'PE':
+                if r1_flag in (77, 141):
+                    continue
+            else:
+                if r1_flag == 4:
+                    continue
+
+            if mode == 'PE':
+                if r1_flag in (99, 355, 83, 339):
+                    pass
+                elif r1_flag in (147, 403, 163, 419):
+                    assert r2 is not None and tmp_r2 is not None
+                    tmp_r1, tmp_r2 = r2.split('\t'), r1.split('\t')
+                else:
+                    continue
+
+                randommer = tmp_r1[0].split(':')[0]
+                first2 = randommer[:2]
+                if first2 in filehandles and r2 is not None:
+                    filehandles[first2].write(f'{r1}\n{r2}\n')
+            else:
+                if r1_flag not in (16, 272, 0, 256):
+                    continue
+                read_name_parts = tmp_r1[0].split('_')
+                randommer = read_name_parts[-1]
+                first2 = randommer[:2]
+                if first2 in filehandles:
+                    filehandles[first2].write(f'{r1}\n')
+    finally:
+        for fh in filehandles.values():
+            fh.close()
+
+    return 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tests/test_split_merge_parity.py
+++ b/tests/test_split_merge_parity.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import gzip
+import hashlib
+import math
+import subprocess
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+PERL_SPLIT = REPO / 'bin/perl/split_bam_to_subfiles_SEorPE.pl'
+PY_SPLIT = REPO / 'bin/python/split_bam_to_subfiles_SEorPE.py'
+PERL_MERGE = REPO / 'bin/perl/merge_multiple_parsed_files.simplified_20191022.pl'
+PY_MERGE = REPO / 'bin/python/merge_multiple_parsed_files.simplified_20191022.py'
+
+
+def sha256_file(path: Path) -> str:
+    h = hashlib.sha256()
+    with path.open('rb') as fh:
+        while True:
+            chunk = fh.read(1024 * 1024)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def unzip_to(src_gz: Path, dst: Path) -> None:
+    with gzip.open(src_gz, 'rt', encoding='utf-8', errors='replace') as src, dst.open('w', encoding='utf-8') as out:
+        out.write(src.read())
+
+
+def test_split_script_parity(tmp_path: Path) -> None:
+    sam_src = REPO / 'tests/fixtures/mini/source/ip.preRmDup.sam.mini.gz'
+    sam = tmp_path / 'ip.preRmDup.sam'
+    unzip_to(sam_src, sam)
+
+    perl_dir = tmp_path / 'perl_split'
+    py_dir = tmp_path / 'py_split'
+    perl_dir.mkdir()
+    py_dir.mkdir()
+
+    subprocess.run(['perl', str(PERL_SPLIT), str(sam), 'SE'], cwd=perl_dir, check=True)
+    subprocess.run(['python3', str(PY_SPLIT), str(sam), 'SE'], cwd=py_dir, check=True)
+
+    perl_files = sorted(perl_dir.glob('*.tmp'))
+    py_files = sorted(py_dir.glob('*.tmp'))
+
+    assert len(perl_files) == 25
+    assert len(py_files) == 25
+    assert [p.name for p in perl_files] == [p.name for p in py_files]
+
+    for p_perl, p_py in zip(perl_files, py_files):
+        assert sha256_file(p_perl) == sha256_file(p_py), f'mismatch: {p_perl.name}'
+
+
+def parse_merged(path: Path):
+    headers: dict[str, tuple[int, float | None]] = {}
+    totals: dict[str, int] = {}
+    elements: dict[str, tuple[str, int, str]] = {}
+
+    with path.open('r', encoding='utf-8', errors='replace') as fh:
+        for raw in fh:
+            line = raw.rstrip('\n')
+            cols = line.split('\t')
+            if cols[0] == '#READINFO':
+                key = cols[1]
+                count = int(float(cols[2]))
+                frac = float(cols[3]) if len(cols) > 3 else None
+                headers[key] = (count, frac)
+            elif cols[0] == 'TOTAL':
+                totals[cols[1]] = int(float(cols[2]))
+            elif cols[0] == 'ELEMENT':
+                # ELEMENT primary readnum frac element_id gene_id
+                elements[cols[4]] = (cols[1], int(float(cols[2])), cols[5])
+
+    return headers, totals, elements
+
+
+def test_merge_script_parity(tmp_path: Path) -> None:
+    ip_parsed = tmp_path / 'ip.prefix.parsed_v2.20201210.txt'
+    input_parsed = tmp_path / 'input.prefix.parsed_v2.20201210.txt'
+
+    ip_parsed.write_text(
+        '\n'.join(
+            [
+                '#READINFO\tAll reads:\t100\tPCR duplicates removed:\t20\tUsable Remaining:\t80\tUsable from genomic mapping:\t30\tUsable from family mapping:\t50',
+                '#READINFO\tUsableReads\t80',
+                '#READINFO\tGenomicReads\t30\t0.375',
+                '#READINFO\tRepFamilyReads\t50\t0.625',
+                'TOTAL\tRNA18S\t20\t250000',
+                'TOTAL\tRNA28S\t30\t375000',
+                'ELEMENT\tRNA18S\t12\t150000\tRNA18S||ENST1\tGENE1',
+                'ELEMENT\tRNA28S\t18\t225000\tRNA28S||ENST2\tGENE2',
+            ]
+        )
+        + '\n',
+        encoding='utf-8',
+    )
+    input_parsed.write_text(
+        '\n'.join(
+            [
+                '#READINFO\tAll reads:\t200\tPCR duplicates removed:\t40\tUsable Remaining:\t160\tUsable from genomic mapping:\t60\tUsable from family mapping:\t100',
+                '#READINFO\tUsableReads\t160',
+                '#READINFO\tGenomicReads\t60\t0.375',
+                '#READINFO\tRepFamilyReads\t100\t0.625',
+                'TOTAL\tRNA18S\t40\t250000',
+                'TOTAL\tRNA28S\t60\t375000',
+                'ELEMENT\tRNA18S\t25\t156250\tRNA18S||ENST1\tGENE1',
+                'ELEMENT\tRNA28S\t35\t218750\tRNA28S||ENST2\tGENE2',
+            ]
+        )
+        + '\n',
+        encoding='utf-8',
+    )
+
+    perl_out = tmp_path / 'merged.perl.parsed'
+    py_out = tmp_path / 'merged.py.parsed'
+
+    subprocess.run(
+        ['perl', str(PERL_MERGE), str(perl_out), str(ip_parsed), str(input_parsed)],
+        check=True,
+    )
+    subprocess.run(
+        ['python3', str(PY_MERGE), str(py_out), str(ip_parsed), str(input_parsed)],
+        check=True,
+    )
+
+    perl_h, perl_t, perl_e = parse_merged(perl_out)
+    py_h, py_t, py_e = parse_merged(py_out)
+
+    assert perl_t == py_t
+    assert perl_e == py_e
+
+    assert perl_h.keys() == py_h.keys()
+    for key in perl_h:
+        p_count, p_frac = perl_h[key]
+        y_count, y_frac = py_h[key]
+        assert p_count == y_count
+        if p_frac is None or y_frac is None:
+            assert p_frac == y_frac
+        else:
+            assert math.isclose(p_frac, y_frac, rel_tol=1e-12, abs_tol=1e-12), key


### PR DESCRIPTION
## Summary
- add Python conversion for split_bam_to_subfiles_SEorPE
- add Python conversion for merge_multiple_parsed_files.simplified_20191022
- add parity test comparing Perl and Python outputs for both scripts

## Validation
- /Users/brianyee/Documents/github/repetitive-element-mapping/.conda-env/bin/python -m pytest -q tests/test_mini_fixtures_manifest.py tests/test_split_merge_parity.py