### PR TITLE
Step 4b: Add Python shims for remaining SE/PE Perl entrypoints

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -112,6 +112,7 @@ tests/*
 !tests/fixtures/**
 !tests/test_mini_fixtures_manifest.py
 !tests/test_split_merge_parity.py
+!tests/test_python_shims.py
 tests/__pycache__/
 tests/*.pyc
 

--- a/bin/python/_perl_compat.py
+++ b/bin/python/_perl_compat.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+
+def run_perl_script(perl_script: Path, argv: list[str]) -> int:
+    cmd = ['perl', str(perl_script), *argv]
+    completed = subprocess.run(cmd)
+    return completed.returncode
+
+
+def resolve_perl_script(perl_basename: str) -> Path:
+    here = Path(__file__).resolve().parent
+    repo = here.parents[1]
+    return repo / 'bin' / 'perl' / perl_basename
+
+
+def main(perl_basename: str) -> int:
+    perl_script = resolve_perl_script(perl_basename)
+    if not perl_script.exists():
+        print(f'Could not find perl script: {perl_script}', file=sys.stderr)
+        return 2
+    return run_perl_script(perl_script, sys.argv[1:])

--- a/bin/python/duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.py
+++ b/bin/python/duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from _perl_compat import main
+
+
+if __name__ == '__main__':
+    raise SystemExit(
+        main('duplicate_removal_inline_paired.count_region_other_reads_masksnRNAs_andreparse_SEandPE_20201210_simple.pl')
+    )

--- a/bin/python/parse_bowtie2_output_realtime_includemultifamily_PE.py
+++ b/bin/python/parse_bowtie2_output_realtime_includemultifamily_PE.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from _perl_compat import main
+
+
+if __name__ == '__main__':
+    raise SystemExit(main('parse_bowtie2_output_realtime_includemultifamily_PE.pl'))

--- a/bin/python/parse_bowtie2_output_realtime_includemultifamily_SE.py
+++ b/bin/python/parse_bowtie2_output_realtime_includemultifamily_SE.py
@@ -1,0 +1,8 @@
+#!/usr/bin/env python3
+from __future__ import annotations
+
+from _perl_compat import main
+
+
+if __name__ == '__main__':
+    raise SystemExit(main('parse_bowtie2_output_realtime_includemultifamily_SE.pl'))

--- a/tests/test_python_shims.py
+++ b/tests/test_python_shims.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO = Path(__file__).resolve().parents[1]
+SHIM = REPO / 'bin/python/_perl_compat.py'
+
+
+def load_module(path: Path):
+    spec = importlib.util.spec_from_file_location('perl_compat_test', path)
+    assert spec is not None and spec.loader is not None
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_resolve_perl_script_path() -> None:
+    mod = load_module(SHIM)
+    resolved = mod.resolve_perl_script('split_bam_to_subfiles_SEorPE.pl')
+    assert resolved.exists()
+    assert resolved.name == 'split_bam_to_subfiles_SEorPE.pl'
+
+
+def test_missing_perl_script_returns_nonzero() -> None:
+    mod = load_module(SHIM)
+    rc = mod.main('__definitely_missing__.pl')
+    assert rc == 2


### PR DESCRIPTION
## Summary
- add reusable Perl-compat helper for Python entrypoints
- add Python CLI shims for SE parser, PE parser, and dedup scripts with identical args passthrough
- add shim tests and keep full test suite green

## Validation
- /Users/brianyee/Documents/github/repetitive-element-mapping/.conda-env/bin/python -m pytest -q tests/test_mini_fixtures_manifest.py tests/test_split_merge_parity.py tests/test_python_shims.py